### PR TITLE
Alternative version using dependent props

### DIFF
--- a/ConsoleApplication1/Program.fs
+++ b/ConsoleApplication1/Program.fs
@@ -7,22 +7,18 @@ type Main = XAML<"Main.xaml">
 
 type ViewModel() as vm =
     inherit ViewModule.ViewModelBase()
-    let mutable show = false
-
-    // This needs to be let bound, since you're referring to it via the property later
-    // If it's created as the property's getter, it's a _new instance_ each time you 
-    // call vm.DependentCommand, which means the original (bound to view) instance
-    // never gets notified
-    let dc = vm.Factory.CommandSyncChecked(
-                (fun _ -> MessageBox.Show "Dependent!" |> ignore),
-                fun _ -> show)
-
-    member __.DependentCommand = dc        
-    member __.MainCommand =
-        vm.Factory.CommandSync(fun _ ->
-            show <- true
-            // I would expect DependentCommand to become available after this next call.
-            vm.DependentCommand.RaiseCanExecuteChanged())
+    let show = vm.Factory.Backing(<@ vm.Show @>, false)
+    
+    member private __.Show with get() = show.Value and set(v) = show.Value <- v
+    member this.DependentCommand = 
+        this.Factory.CommandSyncChecked(
+            (fun _ -> MessageBox.Show "Dependent!" |> ignore),
+            (fun _ -> this.Show),
+            [ <@ this.Show @> ])
+    member this.MainCommand =
+        this.Factory.CommandSync(fun _ -> this.Show <- true)
+            // Not needed anymore
+            // vm.DependentCommand.RaiseCanExecuteChanged())
 
 [<STAThread>]
 [<EntryPoint>]

--- a/ConsoleApplication1/Program.fs
+++ b/ConsoleApplication1/Program.fs
@@ -8,10 +8,16 @@ type Main = XAML<"Main.xaml">
 type ViewModel() as vm =
     inherit ViewModule.ViewModelBase()
     let mutable show = false
-    member __.DependentCommand =
-        vm.Factory.CommandSyncChecked(
-            (fun _ -> MessageBox.Show "Dependent!" |> ignore),
-            fun _ -> show)
+
+    // This needs to be let bound, since you're referring to it via the property later
+    // If it's created as the property's getter, it's a _new instance_ each time you 
+    // call vm.DependentCommand, which means the original (bound to view) instance
+    // never gets notified
+    let dc = vm.Factory.CommandSyncChecked(
+                (fun _ -> MessageBox.Show "Dependent!" |> ignore),
+                fun _ -> show)
+
+    member __.DependentCommand = dc        
     member __.MainCommand =
         vm.Factory.CommandSync(fun _ ->
             show <- true


### PR DESCRIPTION
Note that, if you use dependent properties, you don't have to worry about this - the initial command gets updated automatically.